### PR TITLE
Rework CI/CD to address pwn request risk

### DIFF
--- a/.github/workflows/build-composite-pr-staging.yml
+++ b/.github/workflows/build-composite-pr-staging.yml
@@ -74,13 +74,14 @@ jobs:
           BUILD_ID: ${{ steps.upload-build.outputs.artifact-id }}
           SHOULD_NOTIFY: ${{ vars.SILENCE_COMPOSITE_PR_MESSAGE != 'true' && github.event.action == 'labeled' && github.event.label.name == 'preview on staging' }}
         run: |
-          echo {"pr_number": "${PR_NUMBER}", "build_id": "${BUILD_ID}", "should_notify": "${SHOULD_NOTIFY}"} > ${{ runner.temp }}/payloads/pr_cd_payload.json
+          mkdir ./payloads
+          echo {\"pr_number\": \"${PR_NUMBER}\", \"build_id\": \"${BUILD_ID}\", \"should_notify\": \"${SHOULD_NOTIFY}\"} > ./payloads/pr_cd_payload.json
       
       - name: Upload PR CD payload
         id: upload-metadata
         uses: actions/upload-artifact@v7
         with:
-          name: pr-cd-payload
-          path: ${{ runner.temp }}/payloads/pr_cd_payload.json
+          name: pr-cd-payload.json
+          path: /payloads/pr_cd_payload.json
 
 # To re-elevate permissions, the next steps are handled in cd_receive_pr_artifact.

--- a/.github/workflows/build-composite-pr-staging.yml
+++ b/.github/workflows/build-composite-pr-staging.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
     types: [labeled, reopened, synchronize]
 
+permissions:
+  artifact-metadata: write
+  contents: read
+
 env:
   TARGET_REPO: ${{ vars.COMPOSITE_TARGET_REPO }}
   PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build-composite-pr-staging.yml
+++ b/.github/workflows/build-composite-pr-staging.yml
@@ -1,0 +1,82 @@
+name: 'Build PR for staging'
+run-name: 'Deploy PR #${{github.event.pull_request.number}} to composite target for staging'
+
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled, reopened, synchronize]
+
+env:
+  TARGET_REPO: ${{ vars.COMPOSITE_TARGET_REPO }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+  VITE_BASE_URL: ${{ vars.DEFAULT_VITE_BASE_URL }}/staging/${{ github.event.pull_request.number }}
+
+concurrency:
+  group: ci-ngiab-website-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  pr-build:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'preview on staging') && ( github.event.action != 'labeled' || github.event.label.name == 'preview on staging' ) }}
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout PR Branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}       
+          repository: ${{ github.event.pull_request.head.repo.full_name }} 
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Fetch Pepy stats artifact
+        if: vars.SKIP_VITE_PEPY != 'true'
+        run: |
+          if [ -z "$VITE_PEPY_TECH_TOKEN" ]; then
+            echo "Missing Pepy API token. Set VITE_PEPY_TECH_TOKEN or PEPY_TECH_TOKEN in repository secrets."
+            exit 1
+          fi
+
+          curl -sSf \
+            -H "X-API-Key: $VITE_PEPY_TECH_TOKEN" \
+            "$VITE_PEPY_TECH_BASE_URL/api/v2/projects/NGIAB-data-preprocess" \
+            > public/pepy-stats.json
+
+        env:
+          VITE_PEPY_TECH_TOKEN: ${{ secrets.VITE_PEPY_TECH_TOKEN != '' && secrets.VITE_PEPY_TECH_TOKEN || secrets.PEPY_TECH_TOKEN }}
+          VITE_PEPY_TECH_BASE_URL: ${{ secrets.VITE_PEPY_TECH_BASE_URL != '' && secrets.VITE_PEPY_TECH_BASE_URL || 'https://api.pepy.tech' }}
+
+      - name: Install and Build
+        run: |
+          npm install
+          npm run build
+        env:
+          CI: ""
+
+      - name: Upload a Build Artifact
+        id: upload-build
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-${{ env.PR_NUMBER }}
+          path: build/
+      
+      - name: Write PR CD payload to json
+        id: define-metadata
+        env:
+          BUILD_ID: ${{ steps.upload-build.outputs.artifact-id }}
+          SHOULD_NOTIFY: ${{ vars.SILENCE_COMPOSITE_PR_MESSAGE != 'true' && github.event.action == 'labeled' && github.event.label.name == 'preview on staging' }}
+        run: |
+          echo {"pr_number": "${PR_NUMBER}", "build_id": "${BUILD_ID}", "should_notify": "${SHOULD_NOTIFY}"} > ${{ runner.temp }}/payloads/pr_cd_payload.json
+      
+      - name: Upload PR CD payload
+        id: upload-metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-cd-payload
+          path: ${{ runner.temp }}/payloads/pr_cd_payload.json
+
+# To re-elevate permissions, the next steps are handled in cd_receive_pr_artifact.

--- a/.github/workflows/deploy-composite-pr-staging.yml
+++ b/.github/workflows/deploy-composite-pr-staging.yml
@@ -45,10 +45,14 @@ jobs:
       
       - name: Parse payload inputs
         id: parse-json
+        env:
+          TEMP_NUM: fromJson(steps.extract-json.outputs.payload_json).pr_number
+          TEMP_ID: fromJson(steps.extract-json.outputs.payload_json).build_id
+          TEMP_SN: fromJson(steps.extract-json.outputs.payload_json).should_notify
         run: |
-          echo "PR_NUMBER=${{ fromJson(steps.extract-json.outputs.payload_json).pr_number }}" >> $GITHUB_ENV
-          echo "BUILD_ID=${{ fromJson(steps.extract-json.outputs.payload_json).build_id }}" >> $GITHUB_ENV
-          echo "SHOULD_NOTIFY=${{ fromJson(steps.extract-json.outputs.payload_json).should_notify }}" >> $GITHUB_ENV
+          echo "PR_NUMBER=$TEMP_NUM" >> $GITHUB_ENV
+          echo "BUILD_ID=$TEMP_ID" >> $GITHUB_ENV
+          echo "SHOULD_NOTIFY=$TEMP_SN" >> $GITHUB_ENV
       
       - name: Verify and set target path
         run: |

--- a/.github/workflows/deploy-composite-pr-staging.yml
+++ b/.github/workflows/deploy-composite-pr-staging.yml
@@ -1,63 +1,65 @@
+# Security posture: supporting PRs in staging requires running and deploying untrusted code.
+# However, by limiting deployments to the `/staging` subdirectory via this workflow,
+# we minimize the potential attack surface to a known subset of pages.
+
 name: 'Deploy PR to composite target for staging'
-run-name: 'Deploy PR #${{github.event.pull_request.number}} to composite target for staging'
+run-name: 'Deploy PR to composite target for staging'
 
 on:
-  pull_request_target:
-    branches: [main]
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: [Build PR for staging]
+    types:
+      - completed
 
 env:
   TARGET_REPO: ${{ vars.COMPOSITE_TARGET_REPO }}
-  TARGET_PATH: staging/${{ github.event.pull_request.number }}
-  VITE_BASE_URL: ${{ vars.DEFAULT_VITE_BASE_URL }}/staging/${{ github.event.pull_request.number }}
 
 concurrency:
   group: ci-ngiab-website-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
-  pr-build-deploy:
+  pr-deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: pr-staging
-      url: https://ngiab.ciroh.org/${{ env.TARGET_PATH }}
+
     steps:
-
-      - name: Checkout PR Branch
-        uses: actions/checkout@v5
+      - name: Download PR CD payload
+        uses: actions/download-artifact@v8
         with:
-          ref: ${{ github.event.pull_request.head.ref }}       
-          repository: ${{ github.event.pull_request.head.repo.full_name }} 
-
-      - name: Set up Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Fetch Pepy stats artifact
-        if: vars.SKIP_VITE_PEPY != 'true'
+          name: pr-cd-payload
+          path: ${{ runner.temp }}/payloads
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Unpack payload inputs
+        id: extract-json
         run: |
-          if [ -z "$VITE_PEPY_TECH_TOKEN" ]; then
-            echo "Missing Pepy API token. Set VITE_PEPY_TECH_TOKEN or PEPY_TECH_TOKEN in repository secrets."
+          payload=cat ${{ runner.temp }}/pr_cd_payload.json
+          echo "payload_json=$payload" >> $GITHUB_OUTPUT
+          echo $payload
+      
+      - name: Parse payload inputs
+        id: parse-json
+        run: |
+          echo "PR_NUMBER=${{ fromJson(steps.extract-json.outputs.payload_json).pr_number }}" >> $GITHUB_ENV
+          echo "BUILD_ID=${{ fromJson(steps.extract-json.outputs.payload_json).build_id }}" >> $GITHUB_ENV
+          echo "SHOULD_NOTIFY=${{ fromJson(steps.extract-json.outputs.payload_json).should_notify }}" >> $GITHUB_ENV
+      
+      - name: Verify and set target path
+        run: |
+          INT_REGEX='^[0-9]+$'
+          if !["$PR_NUMBER" =~ "$INT_REGEX"]; then
+            echo "Provided PR number '${PR_NUMBER}' is not a valid integer. Aborting." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+          echo "TARGET_PATH=staging/$PR_NUMBER" >> $GITHUB_ENV
 
-          curl -sSf \
-            -H "X-API-Key: $VITE_PEPY_TECH_TOKEN" \
-            "$VITE_PEPY_TECH_BASE_URL/api/v2/projects/NGIAB-data-preprocess" \
-            > public/pepy-stats.json
-
-        env:
-          VITE_PEPY_TECH_TOKEN: ${{ secrets.VITE_PEPY_TECH_TOKEN != '' && secrets.VITE_PEPY_TECH_TOKEN || secrets.PEPY_TECH_TOKEN }}
-          VITE_PEPY_TECH_BASE_URL: ${{ secrets.VITE_PEPY_TECH_BASE_URL != '' && secrets.VITE_PEPY_TECH_BASE_URL || 'https://api.pepy.tech' }}
-
-      - name: Install and Build
-        run: |
-          npm install
-          npm run build
-        env:
-          CI: ""
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          artifact-ids: ${{ env.BUILD_ID }}
+          path: build/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to composite repository
         uses: JamesIves/github-pages-deploy-action@v4
@@ -69,11 +71,10 @@ jobs:
           clean: true # Set to false if deploying to a composite repository's root!
           git-config-name: "github-actions"
           git-config-email: "github-actions@github.com"
-
       
       - name: Comment PR with staging link
         uses: mshick/add-pr-comment@v2
-        if: vars.SILENCE_COMPOSITE_PR_MESSAGE != 'true'
+        if: ${{ vars.SILENCE_COMPOSITE_PR_MESSAGE != 'true' && env.SHOULD_NOTIFY == 'true' }}
         with:
           message: |
             **Staging Preview:**

--- a/.github/workflows/deploy-composite-pr-staging.yml
+++ b/.github/workflows/deploy-composite-pr-staging.yml
@@ -32,14 +32,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: pr-cd-payload
-          path: ${{ runner.temp }}/payloads
+          path: ${{ runner.temp }}/
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Unpack payload inputs
         id: extract-json
         run: |
-          payload=cat ${{ runner.temp }}/pr_cd_payload.json
+          payload=`cat ${{ runner.temp }}/pr_cd_payload.json`
           echo "payload_json=$payload" >> $GITHUB_OUTPUT
           echo $payload
       

--- a/.github/workflows/deploy-composite-pr-staging.yml
+++ b/.github/workflows/deploy-composite-pr-staging.yml
@@ -11,6 +11,11 @@ on:
     types:
       - completed
 
+permissions:
+  artifact-metadata: write
+  contents: read
+  pull_request: write
+
 env:
   TARGET_REPO: ${{ vars.COMPOSITE_TARGET_REPO }}
 

--- a/.github/workflows/deploy-composite-pr-staging.yml
+++ b/.github/workflows/deploy-composite-pr-staging.yml
@@ -14,7 +14,7 @@ on:
 permissions:
   artifact-metadata: write
   contents: read
-  pull_request: write
+  pull-requests: write
 
 env:
   TARGET_REPO: ${{ vars.COMPOSITE_TARGET_REPO }}
@@ -46,9 +46,9 @@ jobs:
       - name: Parse payload inputs
         id: parse-json
         env:
-          TEMP_NUM: fromJson(steps.extract-json.outputs.payload_json).pr_number
-          TEMP_ID: fromJson(steps.extract-json.outputs.payload_json).build_id
-          TEMP_SN: fromJson(steps.extract-json.outputs.payload_json).should_notify
+          TEMP_NUM: ${{ fromJson(steps.extract-json.outputs.payload_json).pr_number }}
+          TEMP_ID: ${{ fromJson(steps.extract-json.outputs.payload_json).build_id }}
+          TEMP_SN: ${{ fromJson(steps.extract-json.outputs.payload_json).should_notify }}
         run: |
           echo "PR_NUMBER=$TEMP_NUM" >> $GITHUB_ENV
           echo "BUILD_ID=$TEMP_ID" >> $GITHUB_ENV
@@ -59,6 +59,9 @@ jobs:
           INT_REGEX='^[0-9]+$'
           if !["$PR_NUMBER" =~ "$INT_REGEX"]; then
             echo "Provided PR number '${PR_NUMBER}' is not a valid integer. Aborting." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          elif !["$BUILD_ID" =~ "$INT_REGEX"]; then
+            echo "Provided build id '${BUILD_ID}' is not a valid integer. Aborting." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
           echo "TARGET_PATH=staging/$PR_NUMBER" >> $GITHUB_ENV


### PR DESCRIPTION
See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target.

Changes:
- Staging PR deployments are now routed through `pull_request` and `workflow_call`.
  - Staging PRs will no longer be built using secrets if they come from a foreign branch.
- Staging PR deployments only trigger if given the "preview on staging" label by a maintainer.

Security posture:
- Organizationally, we've determined that staging support for external PRs is a high-priority feature. Given that this task inherently requires running external code, which may be untrusted and pose a risk of pwn requests, we have to make some compromises.
- To minimize the risks posed by this requirement:
  - Staging previews must now be pre-approved by a maintainer with the "preview on staging" label. (This mitigates attacks from unknown accounts, but still leaves the risk of untrusted code being added to a PR repository after the fact.)
  - Untrusted code is no longer run with elevated permissions.
  - Untrusted build artifacts are restricted to upload paths of the form `staging/##`, minimizing the risk of a malicious webpage being uploaded to a public-facing location.